### PR TITLE
Replace np.trapz calls with np.trapezoid calls

### DIFF
--- a/mavisetc/background/eso_sky.py
+++ b/mavisetc/background/eso_sky.py
@@ -109,7 +109,7 @@ class sky_source():
                                   ftrans, left=0., right=0.), dtype=float)
 
         #normalize transmission
-        ttrans = np.trapz(np.copy(trans_interp)/wavelength, wavelength)
+        ttrans = np.trapezoid(np.copy(trans_interp)/wavelength, wavelength)
         if ttrans < self.small_num: ttrans = 1.
         ntrans = np.maximum(trans_interp / ttrans, 0.0)
         
@@ -159,15 +159,15 @@ class sky_source():
             self._set_filter(self.obs_band, self.wavelength)
 
         emm_cgs = np.copy(self.emm)*self.h*self.wavelength / 100**2 #erg/s/cm^2/Hz/arcsec^2
-        num = np.trapz(self.wavelength*emm_cgs*self.transmission, self.wavelength)
-        denom = np.trapz(self.wavelength*self.transmission, self.wavelength)
+        num = np.trapezoid(self.wavelength*emm_cgs*self.transmission, self.wavelength)
+        denom = np.trapezoid(self.wavelength*self.transmission, self.wavelength)
             
         self.default_sky_mag = -2.5*np.log10(num/denom) - 48.6
 
         if self.obs_mag is not None: #compute scale factor for the sky
             #emm_cgs = np.copy(self.emm)*self.h*self.wavelength / 100**2 #erg/s/cm^2/Hz/arcsec^2
-            #num = np.trapz(self.wavelength*emm_cgs*self.transmission, self.wavelength)
-            #denom = np.trapz(self.wavelength*self.transmission, self.wavelength)
+            #num = np.trapezoid(self.wavelength*emm_cgs*self.transmission, self.wavelength)
+            #denom = np.trapezoid(self.wavelength*self.transmission, self.wavelength)
             
             #mag = -2.5*np.log10(num/denom) - 48.6
             scale = 10**(-0.4*self.obs_mag)/10**(-0.4*self.default_sky_mag)

--- a/mavisetc/filters/filters.py
+++ b/mavisetc/filters/filters.py
@@ -35,7 +35,7 @@ class Filter(object):
 
         if self.pivot is None:
             wl, tran = self.trans_cache
-            self.pivot = np.sqrt(np.trapz(wl*tran, wl) / np.trapz(tran/wl, wl))
+            self.pivot = np.sqrt(np.trapezoid(wl*tran, wl) / np.trapezoid(tran/wl, wl))
 
         return self.pivot
 

--- a/mavisetc/instruments/imager.py
+++ b/mavisetc/instruments/imager.py
@@ -59,7 +59,7 @@ class ImagingInstrument:
                                   ftrans, left=0., right=0.), dtype=float)
 
         #normalize transmission
-        ttrans = np.trapz(np.copy(trans_interp), self.inst_wavelength)
+        ttrans = np.trapezoid(np.copy(trans_interp), self.inst_wavelength)
         if ttrans < self.small_num: ttrans = 1.
         ntrans = np.maximum(trans_interp / ttrans, 0.0)
         
@@ -383,8 +383,8 @@ class ImagingInstrument:
 
 
                 #compute an effetive pivot wavelength given the throughput
-                store_pivot.append(np.sqrt(np.trapz(self.transmission*self.trans_norm*self.inst_wavelength, self.inst_wavelength)/\
-                                   np.trapz(self.transmission*self.trans_norm/self.inst_wavelength, self.inst_wavelength)))
+                store_pivot.append(np.sqrt(np.trapezoid(self.transmission*self.trans_norm*self.inst_wavelength, self.inst_wavelength)/\
+                                   np.trapezoid(self.transmission*self.trans_norm/self.inst_wavelength, self.inst_wavelength)))
     
             return store_pivot, store_obs, store_perf #check that these are reasonable magnitudes?
 

--- a/mavisetc/sources/flat_models.py
+++ b/mavisetc/sources/flat_models.py
@@ -44,7 +44,7 @@ class flat_source():
                                   ftrans, left=0., right=0.), dtype=float)
 
         #normalize transmission
-        ttrans = np.trapz(np.copy(trans_interp)/self.wavelength, self.wavelength)
+        ttrans = np.trapezoid(np.copy(trans_interp)/self.wavelength, self.wavelength)
         if ttrans < self.small_num: ttrans = 1.
         ntrans = np.maximum(trans_interp / ttrans, 0.0)
         
@@ -77,8 +77,8 @@ class flat_source():
 
     def _get_mag(self):
         #compute observed frame magnitudes or flux
-        num = np.trapz(self.wavelength*self.flux*self.transmission, self.wavelength)
-        denom = np.trapz(self.wavelength*self.transmission, self.wavelength)
+        num = np.trapezoid(self.wavelength*self.flux*self.transmission, self.wavelength)
+        denom = np.trapezoid(self.wavelength*self.transmission, self.wavelength)
 
         return -2.5*np.log10(num/denom) - 48.6
     

--- a/mavisetc/sources/lasd_models.py
+++ b/mavisetc/sources/lasd_models.py
@@ -83,7 +83,7 @@ class lasd_source():
 #                                  ftrans, left=0., right=0.), dtype=float)
 #
 #        #normalize transmission
-#        ttrans = np.trapz(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
+#        ttrans = np.trapezoid(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
 #        if ttrans < self.small_num: ttrans = 1.
 #        ntrans = np.maximum(trans_interp / ttrans, 0.0)
 #        
@@ -150,8 +150,8 @@ class lasd_source():
  
 #    def _get_mag(self):
 #        #compute observed frame magnitudes or flux
-#        num = np.trapz(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
-#        denom = np.trapz(self.red_wavelength*self.transmission, self.red_wavelength)
+#        num = np.trapezoid(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
+#        denom = np.trapezoid(self.red_wavelength*self.transmission, self.red_wavelength)
 #
 #        return -2.5*np.log10(num/denom) - 48.6
                

--- a/mavisetc/sources/template_models.py
+++ b/mavisetc/sources/template_models.py
@@ -86,7 +86,7 @@ class template_source():
                                   ftrans, left=0., right=0.), dtype=float)
 
         #normalize transmission
-        ttrans = np.trapz(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
+        ttrans = np.trapezoid(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
         if ttrans < self.small_num: ttrans = 1.
         ntrans = np.maximum(trans_interp / ttrans, 0.0)
         
@@ -138,8 +138,8 @@ class template_source():
  
     def _get_mag(self):
         #compute observed frame magnitudes or flux
-        num = np.trapz(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
-        denom = np.trapz(self.red_wavelength*self.transmission, self.red_wavelength)
+        num = np.trapezoid(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
+        denom = np.trapezoid(self.red_wavelength*self.transmission, self.red_wavelength)
 
         return -2.5*np.log10(num/denom) - 48.6
                
@@ -234,7 +234,7 @@ class stellar_source():
                                   ftrans, left=0., right=0.), dtype=float)
 
         #normalize transmission
-        ttrans = np.trapz(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
+        ttrans = np.trapezoid(np.copy(trans_interp)/self.red_wavelength, self.red_wavelength)
         if ttrans < self.small_num: ttrans = 1.
         ntrans = np.maximum(trans_interp / ttrans, 0.0)
         
@@ -293,8 +293,8 @@ class stellar_source():
 
     def _get_mag(self):
         #compute observed frame magnitudes or flux
-        num = np.trapz(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
-        denom = np.trapz(self.red_wavelength*self.transmission, self.red_wavelength)
+        num = np.trapezoid(self.red_wavelength*self.template_flux*self.transmission, self.red_wavelength)
+        denom = np.trapezoid(self.red_wavelength*self.transmission, self.red_wavelength)
 
         return -2.5*np.log10(num/denom) - 48.6
 


### PR DESCRIPTION
Replaces all calls to the removed `numpy.trapz` function with equivalent `numpy.trapezoid` calls for NumPy ≥ 2.4 compatibility, fixing Issue #7 in the simplest possible way.

Note that this would break compatibility with NumPy < 2.0. If retaining compatibility with (very) old versions of NumPy is important this PR should not be merged as is and a slightly more complicated fix will be needed.